### PR TITLE
Moment configurable date format

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -8,12 +8,11 @@ import {
 } from "obsidian";
 
 import chrono from "chrono-node";
+import moment from "moment";
 
 var getLastDayOfMonth = function (y: any, m: any) {
   return new Date(y, m, 0).getDate();
 };
-
-var nextDate = new RegExp(/next\s(w+)/, "gi");
 
 const custom = chrono.casual.clone();
 
@@ -124,8 +123,8 @@ export default class NaturalLanguageDates extends Plugin {
     var date = this.getDateString(selectedText);
 
     if (date) {
-      var isodate = date.toISOString().substring(0, 10);
-      var newStr = `[[${isodate}]]`;
+      var momentDate = moment(date).format('YYYY-MM-DD')
+      var newStr = `[[${momentDate}]]`;
       editor.replaceSelection(newStr);
       this.adjustCursor(editor, cursor, newStr, selectedText);
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nldates-obsidian",
-  "version": "0.9.7",
+  "version": "0.2.0",
   "description": "Plugin to parse natural language dates in Obsidian",
   "main": "main.js",
   "scripts": {
@@ -21,6 +21,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "chrono-node": "^2.1.9"
+    "chrono-node": "^2.1.9",
+    "moment": "^2.29.1"
   }
 }


### PR DESCRIPTION
1. Uses [moment](https://momentjs.com/) to allow for more customisable date formatting.
2. Adds a settings tab to set a date format similar to the date format settings for built-in Daily Notes and Templates plugins, defaulting to ISO `YYYY-MM-DD` date format.