### PR TITLE
add newPane parameter to obsidian URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ The only behaviours I changed were the following:
 
 If a date is not recognized, the link won't be created.
 
-**New in v0.4.0**: It's now possible to use the [Obsidian URI](https://publish.obsidian.md/help/Advanced+topics/Using+obsidian+URI) to open daily notes using natural language by using the nldates action `obsidian://nldates?day=<date here>`. Don't forget to [encode space characters](https://publish.obsidian.md/help/Advanced+topics/Using+obsidian+URI#Encoding) appropriately.
+#### [Obsidian URI](https://publish.obsidian.md/help/Advanced+topics/Using+obsidian+URI) **New in v0.4.0**
+
+It's now possible to use the [Obsidian URI](https://publish.obsidian.md/help/Advanced+topics/Using+obsidian+URI) to open daily notes using natural language by using the nldates action `obsidian://nldates?day=<date here>`. Don't forget to [encode space characters](https://publish.obsidian.md/help/Advanced+topics/Using+obsidian+URI#Encoding) appropriately.
+
+| `obsidian://nldates` Parameter | Description |
+| ---------                      | ----------- |
+| `day`                          | natural language date string |
+| `newPane`                      | open note in new pane, default is `yes` |
 
 ## Commands and hotkeys
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -257,6 +257,10 @@ export default class NaturalLanguageDates extends Plugin {
     return result;
   }
 
+  parseTruthy(flag: string): boolean {
+    return ["y", "yes", "1", "t", "true"].indexOf(flag.toLowerCase()) >= 0;
+  }
+
   onTrigger(mode: string) {
     let activeLeaf: any = this.app.workspace.activeLeaf;
     let editor = activeLeaf.view.sourceMode.cmEditor;
@@ -333,6 +337,8 @@ export default class NaturalLanguageDates extends Plugin {
   async actionHandler(params: any) {
 
     let date = this.parseDate(params.day);
+    let newPane = this.parseTruthy(params.newPane || "yes");
+
     console.log(date);
     const {
       workspace
@@ -340,7 +346,12 @@ export default class NaturalLanguageDates extends Plugin {
 
     if (date.moment.isValid()) {
       let dailyNote = await this.getDailyNote(date.moment);
-      const leaf = workspace.splitActiveLeaf();
+
+      let leaf = workspace.activeLeaf;
+      if (newPane) {
+        leaf = workspace.splitActiveLeaf();
+      }
+
       await leaf.openFile(dailyNote);
 
       workspace.setActiveLeaf(leaf);


### PR DESCRIPTION
Adds an optional `newPane` parameter to target either a new pane or the existing active pane.  Defaults to 'yes'.

### Use Case
Mobile shortcuts; having the option to not split really helps on phone screens.