### PR TITLE
Don't trigger autosuggest if preceding char is [a-zA-Z0-9]

### DIFF
--- a/src/suggest/codemirror-suggest.ts
+++ b/src/suggest/codemirror-suggest.ts
@@ -11,7 +11,19 @@ function checkForInputPhrase(
     line: pos.line,
     ch: pos.ch - phrase.length,
   };
-  return cmEditor.getRange(from, pos) === phrase;
+
+  if (cmEditor.getRange(from, pos) !== phrase) {
+    return false;
+  }
+
+  const precedingChar = cmEditor.getRange(
+    {
+      line: pos.line,
+      ch: from.ch - 1,
+    },
+    from
+  );
+  return !precedingChar || /[^`a-zA-Z0-9]/.test(precedingChar);
 }
 
 function isCursorBeforePos(


### PR DESCRIPTION
fixes #38

Well, it doesn't fix the python codeblock issue, but I'm not sure there's much I can do there.