### PR TITLE
Support `@time:now`, `@time:+15 minutes`, etc in auto-suggest

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Argentina Ortega Sáinz 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/suggest/date-suggest.ts
+++ b/src/suggest/date-suggest.ts
@@ -11,7 +11,6 @@ export default class DateSuggest extends CodeMirrorSuggest<IDateCompletion> {
   constructor(app: App, plugin: NaturalLanguageDates) {
     super(app, plugin.settings.autocompleteTriggerPhrase);
     this.plugin = plugin;
-
     this.updateInstructions();
   }
 
@@ -53,6 +52,17 @@ export default class DateSuggest extends CodeMirrorSuggest<IDateCompletion> {
   }
 
   getDateSuggestions(inputStr: string): IDateCompletion[] {
+    if (inputStr.match(/^time/)) {
+      return [
+        "now",
+        "+15 minutes",
+        "+1 hour",
+        "-15 minutes",
+        "-1 hour",
+      ]
+        .map(val => ({label: `time:${val}`}))
+        .filter(item => item.label.toLowerCase().startsWith(inputStr));
+    }
     if (inputStr.match(/(next|last|this)/i)) {
       const reference = inputStr.match(/(next|last|this)/i)[1];
       return [
@@ -106,9 +116,18 @@ export default class DateSuggest extends CodeMirrorSuggest<IDateCompletion> {
 
     const head = this.getStartPos();
     const anchor = this.cmEditor.getCursor();
+    let dateStr = "";
+    let makeIntoLink = this.plugin.settings.autosuggestToggleLink;
 
-    let dateStr = this.plugin.parseDate(suggestion.label).formattedString;
-    if (this.plugin.settings.autosuggestToggleLink) {
+    if (suggestion.label.startsWith("time:")) {
+      let [_, timePart] = suggestion.label.split(":")
+      dateStr = this.plugin.parseTime(timePart).formattedString;
+      makeIntoLink = false;
+    } else {
+      dateStr = this.plugin.parseDate(suggestion.label).formattedString;
+    }
+
+    if (makeIntoLink) {
       if (includeAlias) {
         dateStr = `[[${dateStr}|${suggestion.label}]]`;
       } else {

--- a/src/suggest/date-suggest.ts
+++ b/src/suggest/date-suggest.ts
@@ -120,7 +120,7 @@ export default class DateSuggest extends CodeMirrorSuggest<IDateCompletion> {
     let makeIntoLink = this.plugin.settings.autosuggestToggleLink;
 
     if (suggestion.label.startsWith("time:")) {
-      let [_, timePart] = suggestion.label.split(":")
+      const timePart = suggestion.label.substring(5);
       dateStr = this.plugin.parseTime(timePart).formattedString;
       makeIntoLink = false;
     } else {


### PR DESCRIPTION
First off, thanks for writing this plugin: I very recently decided to adopt [interstitial journaling](https://betterhumans.pub/replace-your-to-do-list-with-interstitial-journaling-to-increase-productivity-4e43109d15ef) and I find this plugin to be a great companion – irreplaceable even – for doing so in Obsidian.

Among the things I like about this plugin is the auto-suggest feature to insert date slugs from a natural language date input via `@`. What I wish it can do is insert time-strings via this feature. I know there is a command that does exactly this from the command palette, which works well, but I think an `@`-based  expansion would be more streamlined and much quicker in practice, especially when you are in a writing flow.

So here is a PR to support that:

![Screen Shot 2021-06-01 at 4 24 00 PM](https://user-images.githubusercontent.com/1437428/120401908-d0c0bb80-c2f5-11eb-9c7e-39a390a6c5ad.png)

(I personally find it a bit off that these `@time:...` suggestions do not expand to a link like the date-based ones, but I think it makes more practical sense.)
