### PR TITLE
Implement lowercase usage of today,tomorrow, and yesterday within autocomplete

### DIFF
--- a/src/suggest/date-suggest.ts
+++ b/src/suggest/date-suggest.ts
@@ -85,9 +85,29 @@ export default class DateSuggest extends EditorSuggest<IDateCompletion> {
       ].filter((items) => items.label.toLowerCase().startsWith(context.query));
     }
 
-    return [{ label: "Today" }, { label: "Yesterday" }, { label: "Tomorrow" }].filter(
-      (items) => items.label.toLowerCase().startsWith(context.query)
+    const firstChar = context.query.charAt(0);
+    const lowerCaseQuery =
+      firstChar != firstChar.toUpperCase() ? "lowercase" : "uppercase";
+
+    const dateSuggestions = {
+      uppercase: [
+        { label: "Today" },
+        { label: "Yesterday" },
+        { label: "Tomorrow" },
+      ],
+      lowercase: [
+        { label: "today" },
+        { label: "yesterday" },
+        { label: "tomorrow" },
+      ],
+    };
+
+    const dateSuggest = dateSuggestions[lowerCaseQuery].filter((items) =>
+      items.label.startsWith(context.query)
     );
+
+    return dateSuggest;
+    
   }
 
   renderSuggestion(suggestion: IDateCompletion, el: HTMLElement): void {


### PR DESCRIPTION
Stemmed from [this issue](https://github.com/argenos/nldates-obsidian/issues/143).

FIxes https://github.com/argenos/nldates-obsidian/issues/143

Have implemented it so it still defaults to uppercase suggestions, but filling out with lowercase then allows for switching into this mode as well as subsequently displaying lowercase aliases. 

![Jul-03-2024 18-35-53](https://github.com/argenos/nldates-obsidian/assets/6904599/e81aeb48-3f88-4e45-828e-714788b5950e)
