### PR TITLE
support adding prefix phrase to the autosuggest

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Typing `@today` <kbd>Enter</kbd> will automatically be expanded to the current d
 | Setting         | Description                                             | Default |
 | --------------- | ------------------------------------------------------- | ------- |
 | Enable/Disable  | A global toggle to enable or disable the autosuggest    | Enabled |
+| Prefix phrase | Characters(s) added to the beginning of a date suggestion | `time:` or `#`  | 
 | Trigger phrase  | Character(s) required to open the autosuggest           | `@`     |
 | Insert as link? | Dates will be inserted as wikilinks (i.e. `[[<date>]]`) | Yes     |
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "nldates-obsidian",
-  "name": "Natural Language Dates",
+  "name": "Natural Language Dates [PZ]",
   "description": "Create date-links based on natural language",
-  "version": "0.6.2",
+  "version": "0.6.3.beta",
   "author": "Argentina Ortega Sainz",
   "authorUrl": "https://argentinaos.com/",
   "isDesktopOnly": false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,7 @@ export type DayOfWeek =
 export interface NLDSettings {
   autosuggestToggleLink: boolean;
   autocompleteTriggerPhrase: string;
+  autocompletePrefixPhrase: string;
   isAutosuggestEnabled: boolean;
 
   format: string;
@@ -30,6 +31,7 @@ export interface NLDSettings {
 export const DEFAULT_SETTINGS: NLDSettings = {
   autosuggestToggleLink: true,
   autocompleteTriggerPhrase: "@",
+  autocompletePrefixPhrase: "",
   isAutosuggestEnabled: true,
 
   format: "YYYY-MM-DD",
@@ -161,6 +163,21 @@ export class NLDSettingsTab extends PluginSettingTab {
           .setValue(this.plugin.settings.autosuggestToggleLink)
           .onChange(async (value) => {
             this.plugin.settings.autosuggestToggleLink = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
+      .setName("Prefix")
+      .setDesc(
+        "Characters(s) that will be added before the date, which can be used for formatting"
+      )
+      .addMomentFormat((text) =>
+        text
+          .setPlaceholder(DEFAULT_SETTINGS.autocompletePrefixPhrase)
+          .setValue(this.plugin.settings.autocompletePrefixPhrase || "")
+          .onChange(async (value) => {
+            this.plugin.settings.autocompletePrefixPhrase = value.trim();
             await this.plugin.saveSettings();
           })
       );

--- a/src/suggest/date-suggest.ts
+++ b/src/suggest/date-suggest.ts
@@ -100,6 +100,7 @@ export default class DateSuggest extends EditorSuggest<IDateCompletion> {
     const includeAlias = event.shiftKey;
     let dateStr = "";
     let makeIntoLink = this.plugin.settings.autosuggestToggleLink;
+    let datePrefix = this.plugin.settings.autocompletePrefixPhrase;
 
     if (suggestion.label.startsWith("time:")) {
       const timePart = suggestion.label.substring(5);
@@ -109,6 +110,10 @@ export default class DateSuggest extends EditorSuggest<IDateCompletion> {
       dateStr = this.plugin.parseDate(suggestion.label).formattedString;
     }
 
+    if (datePrefix) {
+      dateStr = datePrefix + " " + dateStr;
+    }
+    
     if (makeIntoLink) {
       dateStr = generateMarkdownLink(
         this.app,


### PR DESCRIPTION
Example usage: adding `#` to autosuggest time string, so to make it a level 1 heading. 